### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     methods,
     Rcpp (>= 0.12.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.1.1),
     data.table,
     tidyr,
@@ -55,8 +55,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make
 URL: https://github.com/bgoussen/BeeGUTS
 BugReports: https://github.com/bgoussen/BeeGUTS/issues

--- a/inst/stan/GUTS_IT.stan
+++ b/inst/stan/GUTS_IT.stan
@@ -7,17 +7,17 @@ functions {
 
 #include /include/common_stan_functions.stan
 
-  real[] TKTD_varIT( real t,
-                     real[] y,
-                     real[] theta,
-                     real[] x_r,
-                     int[]  x_i) {
+  vector TKTD_varIT( real t,
+                     vector y,
+                     array[] real theta,
+                     array[] real x_r,
+                     array[] int  x_i) {
 
     // - parameters
     real kd = theta[1];
 
     // - new variables
-    real dy_dt[1]; //
+    vector[1] dy_dt; //
 
       // - latent variables
     int Nconc = x_i[1]; // Number of point measuring concentration
@@ -36,18 +36,21 @@ functions {
     return(dy_dt);
   }
 
-  matrix solve_TKTD_varIT(real[] y0, real t0, real[] ts, real[] theta, data real[] tconc, data real[] conc, data real[] odeParam){
+  matrix solve_TKTD_varIT(array[] real y0, real t0, array[] real ts, array[] real theta, data array[] real tconc, data array[] real conc, data array[] real odeParam){
 
-    int x_i[1];
+    array[1] int x_i;
     x_i[1] = size(tconc);
-
-    return(to_matrix(
-      integrate_ode_rk45(TKTD_varIT, y0, t0, ts, theta,
-                         to_array_1d(append_row(to_vector(tconc), to_vector(conc))),
-                         x_i,
+    array[size(ts)] vector[1] ode_res
+      = ode_rk45_tol(TKTD_varIT, to_vector(y0), t0, ts,
                          // additional control parameters for the solver: real rel_tol, real abs_tol, int max_num_steps
-                         odeParam[1], odeParam[2], odeParam[3])));
-
+                         odeParam[1], odeParam[2], to_int(odeParam[3]), theta,
+                         to_array_1d(append_row(to_vector(tconc), to_vector(conc))),
+                         x_i);
+    matrix[size(ts), 1] rtn;
+    for(i in 1:size(ts)) {
+      rtn[i] = transpose(ode_res[i]);
+    }
+    return rtn;
   }
 }
 
@@ -65,11 +68,11 @@ data {
 }
 transformed data{
 
-  real<lower=0> y0[1];
-  real odeParam[3];
+  array[1] real<lower=0> y0;
+  array[3] real odeParam;
 
-  real tNsurv_ode[nData_Nsurv]; // time of Nbr survival to include in the ode !
-  real tconc_ode[nData_conc]; // time of Nbr survival to include in the ode !
+  array[nData_Nsurv] real tNsurv_ode; // time of Nbr survival to include in the ode !
+  array[nData_conc] real tconc_ode; // time of Nbr survival to include in the ode !
 
   y0[1] = 1e-20; // cannot start at 0 for log(0)
 
@@ -90,7 +93,7 @@ parameters {
 
   real beta_log10  ;
 
-  real sigma[2 + nDatasets] ;
+  array[2 + nDatasets] real sigma ;
 
 
 }
@@ -98,9 +101,9 @@ transformed parameters{
 
   real kd_log10 = kdMean_log10 + kdSD_log10 * sigma[1] ;
   real mw_log10 = mwMean_log10 + mwSD_log10 * sigma[2] ;
-  real hb_log10[nDatasets];
+  array[nDatasets] real hb_log10;
 
-  real<lower=0> param[1]; //
+  array[1] real<lower=0> param; //
 
   matrix[nData_Nsurv, 1] y_hat;
   vector<lower=0, upper=1>[nData_Nsurv] Psurv_hat;

--- a/inst/stan/GUTS_SD.stan
+++ b/inst/stan/GUTS_SD.stan
@@ -7,11 +7,11 @@ functions {
 
 #include /include/common_stan_functions.stan
 
-  real[] TKTD_varSD( real t,
-                     real[] y,
-                     real[] theta,
-                     real[] x_r,
-                     int[]  x_i) {
+  vector TKTD_varSD( real t,
+                     vector y,
+                     array[] real theta,
+                     array[] real x_r,
+                     array[] int  x_i) {
 
     // - parameters
     real kd = theta[1];
@@ -20,8 +20,8 @@ functions {
     real hb = theta[4];
 
     // - new variables
-    real max_zw[2]; //
-    real dy_dt[2]; //
+    array[2] real max_zw; //
+    vector[2] dy_dt; //
 
     // - latent variables
     int Nconc = x_i[1]; // Number of point measuring concentration
@@ -46,17 +46,22 @@ functions {
     return(dy_dt);
   }
 
-  matrix solve_TKTD_varSD(real[] y0, real t0, real[] ts, real[] theta, data real[] tconc, data real[] conc, data real[] odeParam){
+  matrix solve_TKTD_varSD(array[] real y0, real t0, array[] real ts, array[] real theta, data array[] real tconc, data array[] real conc, data array[] real odeParam){
 
-    int x_i[1];
+    array[1] int x_i;
     x_i[1] = size(tconc);
 
-    return(to_matrix(
-      integrate_ode_rk45(TKTD_varSD, y0, t0, ts, theta,
-                         to_array_1d(append_row(to_vector(tconc), to_vector(conc))),
-                         x_i,
+    array[size(ts)] vector[2] ode_res
+      = ode_rk45_tol(TKTD_varSD, to_vector(y0), t0, ts,
                          // additional control parameters for the solver: real rel_tol, real abs_tol, int max_num_steps
-                          odeParam[1], odeParam[2], odeParam[3])));
+                         odeParam[1], odeParam[2], to_int(odeParam[3]), theta,
+                         to_array_1d(append_row(to_vector(tconc), to_vector(conc))),
+                         x_i);
+    matrix[size(ts), 2] rtn;
+    for(i in 1:size(ts)) {
+      rtn[i] = transpose(ode_res[i]);
+    }
+    return rtn;
   }
 }
 
@@ -73,11 +78,11 @@ data {
 }
 transformed data{
 
-  real<lower=0> y0[2];
-  real odeParam[3];
+  array[2] real<lower=0> y0;
+  array[3] real odeParam;
 
-  real tNsurv_ode[nData_Nsurv]; // time of Nbr survival to include in the ode !
-  real tconc_ode[nData_conc]; // time of Nbr survival to include in the ode !
+  array[nData_Nsurv] real tNsurv_ode; // time of Nbr survival to include in the ode !
+  array[nData_conc] real tconc_ode; // time of Nbr survival to include in the ode !
 
   y0[1] = 0;
   y0[2] = 0;
@@ -98,7 +103,7 @@ transformed data{
 }
 parameters {
 
-  real sigma[3 + nDatasets];
+  array[3 + nDatasets] real sigma;
 
 }
 transformed parameters{
@@ -106,9 +111,9 @@ transformed parameters{
   real kd_log10 = kdMean_log10 + kdSD_log10 * sigma[1];
   real zw_log10 = zwMean_log10 + zwSD_log10 * sigma[2];
   real bw_log10 = bwMean_log10 + bwSD_log10 * sigma[3];
-  real hb_log10[nDatasets];
+  array[nDatasets] real hb_log10;
 
-  real<lower=0> param[4]; //
+  array[4] real<lower=0> param; //
 
   matrix[nData_Nsurv,2] y_hat;
   vector<lower=0, upper=1>[nData_Nsurv] Psurv_hat;

--- a/inst/stan/include/common_stan_functions.stan
+++ b/inst/stan/include/common_stan_functions.stan
@@ -33,7 +33,7 @@ int find_interval_elem(real x, vector sorted, int start_ind){
         int mid_ind;
         real mid;
         // is there a controlled way without being yelled at with a warning?
-        mid_ind = (left_ind + right_ind) / 2;
+        mid_ind = (left_ind + right_ind) %/% 2;
         mid = sorted[mid_ind] - x;
         if (mid == 0) return(mid_ind-1);
         if (left  * mid < 0) { right = mid; right_ind = mid_ind; }

--- a/inst/stan/include/data_guts.stan
+++ b/inst/stan/include/data_guts.stan
@@ -6,24 +6,24 @@ int <lower=1> nDatasets;
 
 // Number of groups
 int<lower=1> nGroup; // Number of groups (one group is combination of one dataset and one treatment)
-int groupDataset[nGroup]; // Corresponding dataset for each group
+array[nGroup] int groupDataset; // Corresponding dataset for each group
 
 // Concentration
 int<lower=1> nData_conc; // length of data for concentration
-real conc[nData_conc]; // concentration
-real tconc[nData_conc]; // time of concentration
+array[nData_conc] real conc; // concentration
+array[nData_conc] real tconc; // time of concentration
 
-int<lower=1> idC_lw[nGroup]; // e.g. 1 6 12 18
-int<lower=1> idC_up[nGroup]; // e.g. 6 12 18 24
+array[nGroup] int<lower=1> idC_lw; // e.g. 1 6 12 18
+array[nGroup] int<lower=1> idC_up; // e.g. 6 12 18 24
 
 // Survivors
 int<lower=1> nData_Nsurv; // number of group: 4
-int Nsurv[nData_Nsurv];
-int Nprec[nData_Nsurv];
-real tNsurv[nData_Nsurv]; // time of Nbr survival
+array[nData_Nsurv] int Nsurv;
+array[nData_Nsurv] int Nprec;
+array[nData_Nsurv] real tNsurv; // time of Nbr survival
 
-int<lower=1> idS_lw[nGroup]; // e.g. 1 6 12 18
-int<lower=1> idS_up[nGroup]; // e.g. 6 12 18 24
+array[nGroup] int<lower=1> idS_lw; // e.g. 1 6 12 18
+array[nGroup] int<lower=1> idS_up; // e.g. 6 12 18 24
 
 // PRIORS
 real hbMean_log10;

--- a/inst/stan/include/gen_quantities_guts.stan
+++ b/inst/stan/include/gen_quantities_guts.stan
@@ -1,9 +1,9 @@
 /* Code adapted from Virgile Baudrot
 https://github.com/virgile-baudrot/gutsRstan */
 
-int Nsurv_ppc[nData_Nsurv];
-int Nsurv_sim[nData_Nsurv];
-int Nsurv_sim_prec[nData_Nsurv];
+array[nData_Nsurv] int Nsurv_ppc;
+array[nData_Nsurv] int Nsurv_sim;
+array[nData_Nsurv] int Nsurv_sim_prec;
 
 vector[nData_Nsurv] log_lik;
 


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax
- `integrate_ode_rk45` replaced by `ode_rk45`

Note that the new `ode_rk45` allows for the inputs to be passed directly (instead of packing them into the `theta`, `x_i`, `x_r` structures), but I've only updated your syntax to work with the current structures. For more guidance on using the new ODE interfaces you can see this case study: https://mc-stan.org/users/documentation/case-studies/convert_odes.html

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
